### PR TITLE
feat(dynamodb item,car): add cars from 1.34 update

### DIFF
--- a/dynamodb_car.tf
+++ b/dynamodb_car.tf
@@ -2539,6 +2539,18 @@ resource "aws_dynamodb_table_item" "car_nissan_xanavi-nismo-gt-r" {
   item = "${data.local_file.car_nissan_xanavi-nismo-gt-r.content}"
 }
 
+# pagani_huayra item
+data "local_file" "car_pagani_huayra" {
+  filename = "${path.module}/item/car/pagani_huayra.json"
+}
+
+resource "aws_dynamodb_table_item" "car_pagani_huayra" {
+  table_name = "${aws_dynamodb_table.car.name}"
+  hash_key   = "${aws_dynamodb_table.car.hash_key}"
+
+  item = "${data.local_file.car_pagani_huayra.content}"
+}
+
 # pagani_zonda-r item
 data "local_file" "car_pagani_zonda-r" {
   filename = "${path.module}/item/car/pagani_zonda-r.json"

--- a/dynamodb_car.tf
+++ b/dynamodb_car.tf
@@ -2035,6 +2035,18 @@ resource "aws_dynamodb_table_item" "car_mclaren_650s-gt3" {
   item = "${data.local_file.car_mclaren_650s-gt3.content}"
 }
 
+# mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing item
+data "local_file" "car_mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing" {
+  filename = "${path.module}/item/car/mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing.json"
+}
+
+resource "aws_dynamodb_table_item" "car_mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing" {
+  table_name = "${aws_dynamodb_table.car.name}"
+  hash_key   = "${aws_dynamodb_table.car.hash_key}"
+
+  item = "${data.local_file.car_mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing.content}"
+}
+
 # mclaren_f1 item
 data "local_file" "car_mclaren_f1" {
   filename = "${path.module}/item/car/mclaren_f1.json"

--- a/dynamodb_car.tf
+++ b/dynamodb_car.tf
@@ -2191,6 +2191,18 @@ resource "aws_dynamodb_table_item" "car_mercedes-benz_sauber-mercedes-c9" {
   item = "${data.local_file.car_mercedes-benz_sauber-mercedes-c9.content}"
 }
 
+# mercedes-benz_slr-mclaren item
+data "local_file" "car_mercedes-benz_slr-mclaren" {
+  filename = "${path.module}/item/car/mercedes-benz_slr-mclaren.json"
+}
+
+resource "aws_dynamodb_table_item" "car_mercedes-benz_slr-mclaren" {
+  table_name = "${aws_dynamodb_table.car.name}"
+  hash_key   = "${aws_dynamodb_table.car.hash_key}"
+
+  item = "${data.local_file.car_mercedes-benz_slr-mclaren.content}"
+}
+
 # mercedes-benz_sls-amg-gr4 item
 data "local_file" "car_mercedes-benz_sls-amg-gr4" {
   filename = "${path.module}/item/car/mercedes-benz_sls-amg-gr4.json"

--- a/dynamodb_car.tf
+++ b/dynamodb_car.tf
@@ -3163,6 +3163,18 @@ resource "aws_dynamodb_table_item" "car_toyota_gr-supra-racing-concept" {
   item = "${data.local_file.car_toyota_gr-supra-racing-concept.content}"
 }
 
+# toyota_gr-supra-rz-2019 item
+data "local_file" "car_toyota_gr-supra-rz-2019" {
+  filename = "${path.module}/item/car/toyota_gr-supra-rz-2019.json"
+}
+
+resource "aws_dynamodb_table_item" "car_toyota_gr-supra-rz-2019" {
+  table_name = "${aws_dynamodb_table.car.name}"
+  hash_key   = "${aws_dynamodb_table.car.hash_key}"
+
+  item = "${data.local_file.car_toyota_gr-supra-rz-2019.content}"
+}
+
 # toyota_mr2-gt-s item
 data "local_file" "car_toyota_mr2-gt-s" {
   filename = "${path.module}/item/car/toyota_mr2-gt-s.json"

--- a/dynamodb_car.tf
+++ b/dynamodb_car.tf
@@ -1915,6 +1915,18 @@ resource "aws_dynamodb_table_item" "car_mazda_atenza-sedan-xd-l-package" {
   item = "${data.local_file.car_mazda_atenza-sedan-xd-l-package.content}"
 }
 
+# mazda_eunos-roadster-na-special-package item
+data "local_file" "car_mazda_eunos-roadster-na-special-package" {
+  filename = "${path.module}/item/car/mazda_eunos-roadster-na-special-package.json"
+}
+
+resource "aws_dynamodb_table_item" "car_mazda_eunos-roadster-na-special-package" {
+  table_name = "${aws_dynamodb_table.car.name}"
+  hash_key   = "${aws_dynamodb_table.car.hash_key}"
+
+  item = "${data.local_file.car_mazda_eunos-roadster-na-special-package.content}"
+}
+
 # mazda_lm55-vision-gran-turismo-gr1 item
 data "local_file" "car_mazda_lm55-vision-gran-turismo-gr1" {
   filename = "${path.module}/item/car/mazda_lm55-vision-gran-turismo-gr1.json"

--- a/item/car/mazda_eunos-roadster-na-special-package.json
+++ b/item/car/mazda_eunos-roadster-na-special-package.json
@@ -1,0 +1,50 @@
+{
+  "__typename": {
+    "S": "Car"
+  },
+  "drivetrain": {
+    "S": "FR"
+  },
+  "createdAt": {
+    "S": "2019-01-30T09:01:55.774Z"
+  },
+  "stability": {
+    "N": "5.0"
+  },
+  "name": {
+    "S": "Eunos Roadster (NA Special Package)"
+  },
+  "weight": {
+    "N": "940"
+  },
+  "cornering": {
+    "N": "1.7"
+  },
+  "division": {
+    "S": "N100"
+  },
+  "braking": {
+    "N": "1.9"
+  },
+  "acceleration": {
+    "N": "3.1"
+  },
+  "updatedAt": {
+    "S": "2019-01-30T09:01:55.774Z"
+  },
+  "carManufacturerId": {
+    "S": "b29f2358-ca31-4068-9abc-c66662473cca"
+  },
+  "power": {
+    "N": "119"
+  },
+  "speed": {
+    "N": "4.1"
+  },
+  "price": {
+    "N": "17000"
+  },
+  "id": {
+    "S": "833d2120-dffc-4467-b2f9-ad93f506c4f2"
+  }
+}

--- a/item/car/mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing.json
+++ b/item/car/mclaren_f1-gtr-bmw-kokusai-kaihatsu-uk-racing.json
@@ -1,0 +1,50 @@
+{
+  "__typename": {
+    "S": "Car"
+  },
+  "drivetrain": {
+    "S": "MR"
+  },
+  "createdAt": {
+    "S": "2019-01-30T09:46:56.723Z"
+  },
+  "stability": {
+    "N": "5.8"
+  },
+  "name": {
+    "S": "McLaren F1 GTR - BMW (Kokusai Kaihatsu UK Racing)"
+  },
+  "weight": {
+    "N": "1050"
+  },
+  "cornering": {
+    "N": "4.0"
+  },
+  "division": {
+    "S": "Gr.3"
+  },
+  "braking": {
+    "N": "3.9"
+  },
+  "acceleration": {
+    "N": "5.9"
+  },
+  "updatedAt": {
+    "S": "2019-01-30T09:46:56.723Z"
+  },
+  "carManufacturerId": {
+    "S": "804d4501-ce81-4899-a018-dd348910bf42"
+  },
+  "power": {
+    "N": "609"
+  },
+  "speed": {
+    "N": "7.7"
+  },
+  "price": {
+    "N": "450000"
+  },
+  "id": {
+    "S": "8414e073-9e51-44f5-8291-284b6ba17293"
+  }
+}

--- a/item/car/mercedes-benz_slr-mclaren.json
+++ b/item/car/mercedes-benz_slr-mclaren.json
@@ -1,0 +1,50 @@
+{
+  "__typename": {
+    "S": "Car"
+  },
+  "drivetrain": {
+    "S": "FR"
+  },
+  "createdAt": {
+    "S": "2019-01-30T11:24:15.892Z"
+  },
+  "stability": {
+    "N": "5.5"
+  },
+  "name": {
+    "S": "SLR McLaren"
+  },
+  "weight": {
+    "N": "1768"
+  },
+  "cornering": {
+    "N": "2.2"
+  },
+  "division": {
+    "S": "N600"
+  },
+  "braking": {
+    "N": "2.2"
+  },
+  "acceleration": {
+    "N": "4.3"
+  },
+  "updatedAt": {
+    "S": "2019-01-30T11:24:15.892Z"
+  },
+  "carManufacturerId": {
+    "S": "c5a6a842-0115-4f0b-a07b-6a76f54a4dfd"
+  },
+  "power": {
+    "N": "625"
+  },
+  "speed": {
+    "N": "9.4"
+  },
+  "price": {
+    "N": "600000"
+  },
+  "id": {
+    "S": "f0f045e6-52b1-4d70-9c95-32b604903cbe"
+  }
+}

--- a/item/car/pagani_huayra.json
+++ b/item/car/pagani_huayra.json
@@ -1,0 +1,50 @@
+{
+  "__typename": {
+    "S": "Car"
+  },
+  "drivetrain": {
+    "S": "MR"
+  },
+  "createdAt": {
+    "S": "2019-01-30T12:02:10.562Z"
+  },
+  "stability": {
+    "N": "5.1"
+  },
+  "name": {
+    "S": "Huayra"
+  },
+  "weight": {
+    "N": "1350"
+  },
+  "cornering": {
+    "N": "2.3"
+  },
+  "division": {
+    "S": "N700"
+  },
+  "braking": {
+    "N": "2.3"
+  },
+  "acceleration": {
+    "N": "4.8"
+  },
+  "updatedAt": {
+    "S": "2019-01-30T12:02:10.562Z"
+  },
+  "carManufacturerId": {
+    "S": "59c38c3e-0fb1-4cc5-8e98-2ab6d215be45"
+  },
+  "power": {
+    "N": "741"
+  },
+  "speed": {
+    "N": "10"
+  },
+  "price": {
+    "N": "1350000"
+  },
+  "id": {
+    "S": "b74fefbd-b545-42de-be37-2b3da5f2dd10"
+  }
+}

--- a/item/car/toyota_gr-supra-rz-2019.json
+++ b/item/car/toyota_gr-supra-rz-2019.json
@@ -1,0 +1,50 @@
+{
+  "__typename": {
+    "S": "Car"
+  },
+  "drivetrain": {
+    "S": "FR"
+  },
+  "createdAt": {
+    "S": "2019-01-30T14:12:59.777Z"
+  },
+  "stability": {
+    "N": "5.0"
+  },
+  "name": {
+    "S": "GR Supra RZ"
+  },
+  "weight": {
+    "N": "1520"
+  },
+  "cornering": {
+    "N": "2"
+  },
+  "division": {
+    "S": "N300"
+  },
+  "braking": {
+    "N": "2.1"
+  },
+  "acceleration": {
+    "N": "4.1"
+  },
+  "updatedAt": {
+    "S": "2019-01-30T14:12:59.777Z"
+  },
+  "carManufacturerId": {
+    "S": "f41adcc0-d916-407a-a243-8142b9fe799c"
+  },
+  "power": {
+    "N": "340"
+  },
+  "speed": {
+    "N": "7.4"
+  },
+  "price": {
+    "N": "100000"
+  },
+  "id": {
+    "S": "2b3511c8-f11a-4e92-99f5-741cd3079eae"
+  }
+}


### PR DESCRIPTION
# Description

add cars from 1.34 update:
- toyota gr supra rz 2019
- pagani huayra
- mercedes benz slr mclaren
- mazda eunos roadster na special package
- mclaren f1 gtr bmw kokusai kaihatsu uk racing

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | yes
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | N/A
| License        | MIT
